### PR TITLE
Add missing dependencies for pnpm build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"devDependencies": {
+				"@codemirror/state": "^6.5.2",
+				"@codemirror/view": "^6.36.3",
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
@@ -25,7 +27,6 @@
 			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@marijn/find-cluster-break": "^1.0.0"
 			}
@@ -36,7 +37,6 @@
 			"integrity": "sha512-N2bilM47QWC8Hnx0rMdDxO2x2ImJ1FvZWXubwKgjeoOrWwEiFrtpA7SFHcuZ+o2Ze2VzbkgbzWVj4+V18LVkeg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.5.0",
 				"style-mod": "^4.1.0",
@@ -581,8 +581,7 @@
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -2268,8 +2267,7 @@
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
 			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -2394,8 +2392,7 @@
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
+		"@codemirror/state": "^6.5.2",
+		"@codemirror/view": "^6.36.3",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",


### PR DESCRIPTION
Hi :wave:,

thanks for providing this useful plugin. I encountered a problem while building the project with `pnpm` (see below). Adding the dependencies in this MR allows building the project with `npm` and `pnpm`.

Let me know what you think.

```bash
# Note npm install && npm run build works though
➜  obsidian-docusaurus-style-admonitions git:(master) ✗ pnpm install
➜  obsidian-docusaurus-style-admonitions git:(master) ✗ pnpm build

> docusaurus-style-admonitions@0.1.0 build /home/toa/Documents/repositories/fork/obsidian-docusaurus-style-admonitions
> tsc -noEmit -skipLibCheck && node esbuild.config.mjs production

main.ts:10:55 - error TS2307: Cannot find module '@codemirror/view' or its corresponding type declarations.

10 import { Decoration, DecorationSet, ViewUpdate } from '@codemirror/view';
                                                         ~~~~~~~~~~~~~~~~~~

main.ts:11:23 - error TS2307: Cannot find module '@codemirror/state' or its corresponding type declarations.

11 import { Range } from '@codemirror/state';
                         ~~~~~~~~~~~~~~~~~~~

main.ts:12:40 - error TS2307: Cannot find module '@codemirror/view' or its corresponding type declarations.

12 import { ViewPlugin, EditorView } from '@codemirror/view';
                                          ~~~~~~~~~~~~~~~~~~

main.ts:277:17 - error TS7006: Parameter 'v' implicitly has an 'any' type.

277    decorations: v => v.decorations
                    ~


Found 4 errors in the same file, starting at: main.ts:10

 ELIFECYCLE  Command failed with exit code 2.

```